### PR TITLE
add blocking marker to blocking map query

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -440,7 +440,7 @@ fn reroute_path<N: Neighborhood + 'static>(
     }
 }
 
-fn update_blocking_map(mut blocking_set: ResMut<BlockingMap>, query: Query<(Entity, &GridPos)>) {
+fn update_blocking_map(mut blocking_set: ResMut<BlockingMap>, query: Query<(Entity, &GridPos), With<Blocking>>) {
     blocking_set.0.clear();
 
     query.iter().for_each(|(entity, position)| {


### PR DESCRIPTION
the blocking map was adding all entities with a GridPos to the blocking map instead of only the ones that have the blocking marker