### PR TITLE
switch insert/remove to try_insert/try_remove

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -140,8 +140,9 @@ impl GridSettingsBuilder {
     /// Initalize a 2D [`Grid`] with the given width and height. Returns a [`GridSettingsBuilder`] that can be further configured.
     pub fn new_2d(width: u32, height: u32) -> Self {
         if width < 3 || height < 3 {
-            panic!("Width and height must be at least 3");
+            log::warn!("Width and height must be at least 3");
         }
+
 
         let mut grid_settings = GridSettingsBuilder {
             dimensions: UVec3::new(width, height, 1),
@@ -156,11 +157,11 @@ impl GridSettingsBuilder {
     /// Initalize a 3D [`Grid`] with the given width, height, and depth. Returns a [`GridSettingsBuilder`] that can be further configured.
     pub fn new_3d(width: u32, height: u32, depth: u32) -> Self {
         if width < 3 || height < 3 {
-            panic!("Width and height must be at least 3");
+            log::warn!("Width and height must be at least 3");
         }
 
         if depth < 1 {
-            panic!("Depth must be at least 1");
+            log::warn!("Depth must be at least 1");
         }
 
         GridSettingsBuilder {
@@ -173,7 +174,7 @@ impl GridSettingsBuilder {
     /// Must be at least 3.
     pub fn chunk_size(mut self, chunk_size: u32) -> Self {
         if chunk_size < 3 {
-            panic!("Chunk size must be at least 3");
+            log::warn!("Chunk size must be at least 3");
         }
 
         self.chunk_settings.size = chunk_size;
@@ -184,7 +185,7 @@ impl GridSettingsBuilder {
     /// Must be at least 1 and the grid's depth must be divisible by the chunk depth.
     pub fn chunk_depth(mut self, chunk_depth: u32) -> Self {
         if chunk_depth < 1 {
-            panic!("Chunk depth must be at least 1");
+            log::warn!("Chunk depth must be at least 1");
         }
 
         self.chunk_settings.depth = chunk_depth;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -160,7 +160,7 @@ pub(crate) struct NeedsPathfinding;
 // Flags all the entities with a changed `Pathfind` component to request pathfinding.
 fn tag_pathfinding_requests(mut commands: Commands, query: Query<Entity, Changed<Pathfind>>) {
     for entity in query.iter() {
-        commands.entity(entity).insert(NeedsPathfinding);
+        commands.entity(entity).try_insert(NeedsPathfinding);
     }
 }
 
@@ -221,9 +221,9 @@ fn pathfind<N: Neighborhood + 'static>(
 
             commands
                 .entity(entity)
-                .insert(path)
-                .remove::<PathfindingFailed>()
-                .remove::<NeedsPathfinding>();
+                .try_insert(path)
+                .try_remove::<PathfindingFailed>()
+                .try_remove::<NeedsPathfinding>();
             // We remove PathfindingFailed even if it's not there.
         } else {
             #[cfg(feature = "stats")]
@@ -231,9 +231,9 @@ fn pathfind<N: Neighborhood + 'static>(
 
             commands
                 .entity(entity)
-                .insert(PathfindingFailed)
-                .remove::<NeedsPathfinding>()
-                .remove::<NextPos>(); // Just to be safe
+                .try_insert(PathfindingFailed)
+                .try_remove::<NeedsPathfinding>()
+                .try_remove::<NextPos>(); // Just to be safe
         }
 
         count += 1;
@@ -278,8 +278,8 @@ fn next_position<N: Neighborhood + 'static>(
         // If the entity still exists and is valid
         if let Ok((entity, mut path, position, pathfind)) = query.get_mut(entity) {
             if position.0 == pathfind.goal {
-                commands.entity(entity).remove::<Path>();
-                commands.entity(entity).remove::<Pathfind>();
+                commands.entity(entity).try_remove::<Path>();
+                commands.entity(entity).try_remove::<Pathfind>();
                 continue;
             }
 
@@ -299,7 +299,7 @@ fn next_position<N: Neighborhood + 'static>(
                 );
 
                 if !success {
-                    commands.entity(entity).insert(AvoidanceFailed);
+                    commands.entity(entity).try_insert(AvoidanceFailed);
                     continue;
                 }
 
@@ -327,7 +327,7 @@ fn next_position<N: Neighborhood + 'static>(
 
                 blocking.0.remove(&position.0);
                 blocking.0.insert(next, entity);
-                commands.entity(entity).insert(NextPos(next));
+                commands.entity(entity).try_insert(NextPos(next));
 
                 // Re-queue for next frame
                 queue.push_back(entity);
@@ -521,11 +521,11 @@ fn reroute_path<N: Neighborhood + 'static>(
             #[cfg(feature = "stats")]
             stats.add_collision(elapsed, new_path.cost() as f64);
 
-            commands.entity(entity).insert(new_path);
-            commands.entity(entity).remove::<AvoidanceFailed>();
+            commands.entity(entity).try_insert(new_path);
+            commands.entity(entity).try_remove::<AvoidanceFailed>();
         } else {
-            commands.entity(entity).insert(RerouteFailed);
-            commands.entity(entity).remove::<AvoidanceFailed>(); // Try again next frame
+            commands.entity(entity).try_insert(RerouteFailed);
+            commands.entity(entity).try_remove::<AvoidanceFailed>(); // Try again next frame
 
             #[cfg(feature = "stats")]
             let elapsed = start.elapsed().as_secs_f64();


### PR DESCRIPTION
Changing this in the plugin systems to avoid any panics if the crate user removes an entity before the world is synced.